### PR TITLE
Fix failing test and python2/3 compatible urlretrieve

### DIFF
--- a/PedicleScrewSimulator/PedicleScrewSimulator.py
+++ b/PedicleScrewSimulator/PedicleScrewSimulator.py
@@ -3,6 +3,7 @@ import unittest
 import vtk, qt, ctk, slicer
 from slicer.ScriptedLoadableModule import *
 import logging
+from six.moves.urllib.request import urlretrieve
 
 import PedicleScrewSimulatorWizard
 
@@ -226,7 +227,6 @@ class PedicleScrewSimulatorTest(ScriptedLoadableModuleTest):
     #
     # first, get some data
     #
-    import urllib
     downloads = (
         ('http://slicer.kitware.com/midas3/download?items=5767', 'FA.nrrd', slicer.util.loadVolume),
         )
@@ -235,7 +235,7 @@ class PedicleScrewSimulatorTest(ScriptedLoadableModuleTest):
       filePath = slicer.app.temporaryPath + '/' + name
       if not os.path.exists(filePath) or os.stat(filePath).st_size == 0:
         logging.info('Requesting download %s from %s...\n' % (name, url))
-        urllib.urlretrieve(url, filePath)
+        urlretrieve(url, filePath)
       if loader:
         logging.info('Loading %s...' % (name,))
         loader(filePath)

--- a/PedicleScrewSimulator/PedicleScrewSimulator.py
+++ b/PedicleScrewSimulator/PedicleScrewSimulator.py
@@ -57,7 +57,7 @@ class PedicleScrewSimulatorWidget(ScriptedLoadableModuleWidget):
     self.screwStep = PedicleScrewSimulatorWizard.ScrewStep( 'Screw' )
     self.gradeStep = PedicleScrewSimulatorWizard.GradeStep( 'Grade' )
     self.endStep = PedicleScrewSimulatorWizard.EndStep( 'Final'  )
-    
+
     # add the wizard steps to an array for convenience
     allSteps = []
 
@@ -68,26 +68,26 @@ class PedicleScrewSimulatorWidget(ScriptedLoadableModuleWidget):
     allSteps.append( self.screwStep)
     allSteps.append( self.gradeStep)
     allSteps.append( self.endStep )
-    
-    
-    # Add transition 
+
+
+    # Add transition
     # Check if volume is loaded
     self.workflow.addTransition( self.loadDataStep, self.defineROIStep )
-    
+
     self.workflow.addTransition( self.defineROIStep, self.landmarksStep, 'pass', ctk.ctkWorkflow.Bidirectional )
     self.workflow.addTransition( self.defineROIStep, self.loadDataStep, 'fail', ctk.ctkWorkflow.Bidirectional  )
-    
+
     self.workflow.addTransition( self.landmarksStep, self.measurementsStep, 'pass', ctk.ctkWorkflow.Bidirectional )
     self.workflow.addTransition( self.landmarksStep, self.measurementsStep, 'fail', ctk.ctkWorkflow.Bidirectional )
-    
+
     self.workflow.addTransition( self.measurementsStep, self.screwStep, 'pass', ctk.ctkWorkflow.Bidirectional )
     self.workflow.addTransition( self.measurementsStep, self.screwStep, 'fail', ctk.ctkWorkflow.Bidirectional )
-    
+
     self.workflow.addTransition( self.screwStep, self.gradeStep, 'pass', ctk.ctkWorkflow.Bidirectional )
     self.workflow.addTransition( self.screwStep, self.gradeStep, 'fail', ctk.ctkWorkflow.Bidirectional )
-          
+
     self.workflow.addTransition( self.gradeStep, self.endStep )
-           
+
     nNodes = slicer.mrmlScene.GetNumberOfNodesByClass('vtkMRMLScriptedModuleNode')
 
     self.parameterNode = None
@@ -102,14 +102,14 @@ class PedicleScrewSimulatorWidget(ScriptedLoadableModuleWidget):
       self.parameterNode = slicer.vtkMRMLScriptedModuleNode()
       self.parameterNode.SetModuleName('PedicleScrewSimulator')
       slicer.mrmlScene.AddNode(self.parameterNode)
- 
+
     for s in allSteps:
         s.setParameterNode (self.parameterNode)
-    
-    
+
+
     # restore workflow step
     currentStep = self.parameterNode.GetParameter('currentStep')
-    
+
     if currentStep != '':
       logging.debug('Restoring workflow step to ' + currentStep)
       if currentStep == 'LoadData':
@@ -121,22 +121,22 @@ class PedicleScrewSimulatorWidget(ScriptedLoadableModuleWidget):
       if currentStep == 'Landmarks':
         self.workflow.setInitialStep(self.landmarksStep)
       if currentStep == 'Screw':
-        self.workflow.setInitialStep(self.screwStep) 
+        self.workflow.setInitialStep(self.screwStep)
       if currentStep == 'Grade':
-        self.workflow.setInitialStep(self.gradeStep)   
+        self.workflow.setInitialStep(self.gradeStep)
       if currentStep == 'Final':
         self.workflow.setInitialStep(self.endStep)
     else:
       logging.debug('currentStep in parameter node is empty')
-    
-    
+
+
     # start the workflow and show the widget
     self.workflow.start()
     workflowWidget.visible = True
     self.layout.addWidget( workflowWidget )
 
     # compress the layout
-    #self.layout.addStretch(1)        
+    #self.layout.addStretch(1)
 
   def cleanup(self):
     pass
@@ -164,8 +164,33 @@ class PedicleScrewSimulatorWidget(ScriptedLoadableModuleWidget):
           imp.load_module(packageName+'.'+submoduleName, f, filename, description)
       finally:
           f.close()
-          
+
     ScriptedLoadableModuleWidget.onReload(self)
+
+
+class PedicleScrewSimulatorLogic(ScriptedLoadableModuleLogic):
+  """This class should implement all the actual
+  computation done by your module.  The interface
+  should be such that other python code can import
+  this class and make use of the functionality without
+  requiring an instance of the Widget.
+  Uses ScriptedLoadableModuleLogic base class, available at:
+  https://github.com/Slicer/Slicer/blob/master/Base/Python/slicer/ScriptedLoadableModule.py
+  """
+
+  def hasImageData(self,volumeNode):
+    """This is an example logic method that
+    returns true if the passed in volume
+    node has valid image data
+    """
+    if not volumeNode:
+      logging.debug('hasImageData failed: no volume node')
+      return False
+    if volumeNode.GetImageData() is None:
+      logging.debug('hasImageData failed: no image data in volume node')
+      return False
+    return True
+
 
 class PedicleScrewSimulatorTest(ScriptedLoadableModuleTest):
   """


### PR DESCRIPTION
1. This fixes a failing test due to a missing PedicleScrewSimulatorLogic class which includes the hasImagedata method. 

2. I've also fixed the use of urlretrieve in the test to be python 2/3 compatible.

3. Also, @lassoan you updated ExtensionsIndex https://github.com/Slicer/ExtensionsIndex/commit/dbca7ff79135f3e7ba2c2e3f89c1288c576d5875 to specify a "4.10" git tag for this repo, but none exists.  This results in the extension [failing](http://slicer.cdash.org/viewConfigure.php?buildid=1609140) to be configured for Slicer-4.10. Briefly looking at the changes you made for python3 support doesn't seem to have broken 4.10 support, but maybe there was some other Slicer API changes.